### PR TITLE
added reference to underscore.js in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ angular-kendo was designed to work with Kendo UI Web / DataViz and AngularJS ver
 angular-kendo currently depends on the following libraries:
 
 - [jQuery](http://www.jquery.com) v1.8.2
+- [Underscore](http://underscorejs.org)
 - [Kendo UI](http://www.kendoui.com) vCurrent
 - [AngularJS](http://www.angularjs.org) v1.0.4
 


### PR DESCRIPTION
angular-kendo initialization code throws an exception if underscore.js library is not included on your page.
