### PR TITLE
fixing typo in app init

### DIFF
--- a/app/partials/home.html
+++ b/app/partials/home.html
@@ -23,7 +23,7 @@
 
 <div class="demo-section">
   <pre class="prettyprint">
-var app = angular.module(&#039;your-angular-app&#039;, [&#039;kendo&#039;]);  
+var app = angular.module(&#039;your-angular-app&#039;, [&#039;kendo.directives&#039;]);  
   </pre>
 </div>
 


### PR DESCRIPTION
when following the on-screen instructions `kendo` was reported as a module not found but looking at the source it appears that `kendo.directives` is correct and after trying that it appeared to work.
