### PR TITLE
Fix for minified version (dependency injection syntax)

### DIFF
--- a/src/services/widget.js
+++ b/src/services/widget.js
@@ -1,4 +1,4 @@
-angular.module('kendo.directives', [], function($provide){
+angular.module('kendo.directives', [], ['$provide', function($provide){
 
   // Iterate over the kendo.ui and kendo.dataviz.ui namespace objects to get the Kendo UI widgets adding
   // them to the 'widgets' array.
@@ -15,4 +15,4 @@ angular.module('kendo.directives', [], function($provide){
 
   $provide.value('kendoWidgets', widgets);
 
-});
+}]);


### PR DESCRIPTION
Currently the minified version (build/angular-kendo.min.js) is broken, because the 'minify-proof-dependency-injection-syntax' was forgotten here.
This pull requests fixes that issue.
