### PR TITLE
feat(conventional-changelog): adds grunt-conventional-changelog task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -51,6 +51,13 @@ module.exports = function(grunt) {
         files: "src/**/*.js",
         tasks: "default"
       }
+    },
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md',
+        github: 'kendo-labs/angular-kendo',
+        version: grunt.file.readJSON('bower.json').version
+      }
     }
   });
 
@@ -64,6 +71,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
 
   grunt.loadNpmTasks('grunt-contrib-watch');
+
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   // Default task(s).
   grunt.registerTask('default', ['concat', 'uglify', 'watch']);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "karma": "~0.8.5",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-docco": "~0.2.0",
-    "grunt-contrib-watch": "~0.4.4"
+    "grunt-contrib-watch": "~0.4.4",
+    "grunt-conventional-changelog": "~0.1.2"
   }
 }


### PR DESCRIPTION
this adds brian's awesome grunt task to generate changelogs automatically
through well-formed commit messages.

there's now a new section in the gruntFile.js called 'changelog', which
specifies the options for the task.

for more information about the grunt plugin checkout btford/grunt-conventional-changelog
its readme file also describes where you can find the specification for
well-formed commit messages.

when running `grunt changelog:FROM_REF` make sure `FROM_REF`  is an existing tag in your repository.
