### PR TITLE
Change bower.main attribute to single angular-kendo artifact

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,5 +10,5 @@
     "angular-mocks": "~1.0.7",
     "kendo-ui": "~2013.1.319"
   }, 
-  "main": "build/*.js"
+  "main": "build/angular-kendo.js"
 }


### PR DESCRIPTION
Change bower.main attribute to single angular-kendo artifact instead wildcard.

Problem: 
Plugins like [grunt-bower-install](https://npmjs.org/package/grunt-bower-install) could automatically create script elements with bower components.
They are using the main attribute of the bower.json of each component and injecting them into the given html file.
With a wildcard at this point in this project, the angular-kendo would be injected two times.

Minification should be done by the final build process, during the development the not minified version should be used for e.g. debugging. 
