### PR TITLE
Fix for RTE when manually bootstrapping angular app.

### DIFF
--- a/src/directives/widgets.js
+++ b/src/directives/widgets.js
@@ -1,15 +1,16 @@
 (function(angular) {
 
-  var widgets = angular.injector(['kendo.directives']).get('kendoWidgets');
+  angular.module('kendo.directives').run([ 'kendoWidgets', function(widgets) {
+		// loop through all the widgets and create a directive
+		angular.forEach(widgets, function(widget) {
+			angular.module('kendo.directives').directive(widget, ['directiveFactory',
+				function(directiveFactory) {
+					return directiveFactory.create(widget);
+				}
+			]);
+		});
 
-  // loop through all the widgets and create a directive
-  angular.forEach(widgets, function(widget) {
-    angular.module('kendo.directives').directive(widget, ['directiveFactory',
-      function(directiveFactory) {
-        return directiveFactory.create(widget);
-      }
-    ]);
-  });
+	} ]);
 
 }(angular));
 


### PR DESCRIPTION
If you manually bootstrap an angular app and don't use the ng-app directive, then widgets.js would throw a RTE trying to get the injector before the module has initialized.

Code should be executed safely as a module run function that is executed on module initialization.
