### PR TITLE
Initial value is not applied from ng-model to widget value

### DIFF
--- a/src/factories/directive.js
+++ b/src/factories/directive.js
@@ -75,6 +75,8 @@ angular.module('kendo.directives').factory('directiveFactory', ['widgetFactory',
                 // Update the widget with the view value.
                 widget.value(ngModel.$viewValue);
               };
+              
+              widget.value(ngModel.$viewValue);
 
               // In order to be able to update the angular scope objects, we need to know when the change event is fired for a Kendo UI Widget.
               widget.bind("change", function(e) {


### PR DESCRIPTION
When using ng-model, need to make sure that the initial value is set by calling widget.value(ngModel.$viewValue), otherwise it may wait for the next change before it updates correctly.
