### PR TITLE
refactor: use single timeout for widget initialization

### DIFF
--- a/src/factories/directive.js
+++ b/src/factories/directive.js
@@ -13,6 +13,10 @@ angular.module('kendo.directives').factory('directiveFactory', ['widgetFactory',
         }
       }
     }
+	
+	// $timeout tracking
+	var $timeoutPromise = null;
+	var unsetTimeoutPromise = function() { $timeoutPromise = null };
 
     var create = function(kendoWidget) {
 
@@ -35,12 +39,18 @@ angular.module('kendo.directives').factory('directiveFactory', ['widgetFactory',
         link: function(scope, element, attrs, ngModel) {
 
           var widget;
+		  
+		  // Instead of having angular digest each component that needs to be setup
+		  // Use the same timeout until the timeout has been executed, this will cause all
+		  //   directives to be evaluated in the next cycle, instead of over multiple cycles.
+		  if (!$timeoutPromise)
+		    $timeoutPromise = $timeout(unsetTimeoutPromise);
 
           // Bind kendo widget to element only once interpolation on attributes is done.
           // Using a $timeout with no delay simply makes sure the function will be executed next in the event queue
           // after the current $digest cycle is finished. Other directives on the same element (select for example)
           // will have been processed, and interpolation will have happened on the attributes.
-          $timeout( function() {
+          $timeoutPromise.then( function() {
 
             // create the kendo widget and bind it to the element.
             widget = widgetFactory.create(scope, element, attrs, kendoWidget);


### PR DESCRIPTION
Update widget initialization to now use a single timeout
- Use same event cycle for all widget's that were initialized from the previous digest cycle
- Leverages the fact that $timeout returns a promise.
- Instead of causing angular to $digest for every single widget, it should only need to digest once per set of widgets.

This also may help with the FOUJUI problem (Issue #18), by making it one cycle to initialize everything then hand off to the browser.
