### PR TITLE
chore(gruntfile): adds matchdep support

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,5 +1,7 @@
 module.exports = function(grunt) {
 
+  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -60,19 +62,6 @@ module.exports = function(grunt) {
       }
     }
   });
-
-  // Load the plugin that provides the "uglify" task.
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-
-  grunt.loadNpmTasks('grunt-docco');
-
-  grunt.loadNpmTasks('grunt-contrib-copy');
-
-  grunt.loadNpmTasks('grunt-contrib-concat');
-
-  grunt.loadNpmTasks('grunt-contrib-watch');
-
-  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   // Default task(s).
   grunt.registerTask('default', ['concat', 'uglify', 'watch']);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-docco": "~0.2.0",
     "grunt-contrib-watch": "~0.4.4",
-    "grunt-conventional-changelog": "~0.1.2"
+    "grunt-conventional-changelog": "~0.1.2",
+    "matchdep": "~0.1.2"
   }
 }


### PR DESCRIPTION
this commit adds the matchdep module which brings easier
grunt plugin handling within our gruntfile configuration.
grunt plugins are now loaded automatically without
specifying each explicitly.
