### PR TITLE
Fixing grunt-concat options for wrapping the build code in an closure

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -6,11 +6,9 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     concat: {
-      config: {
-        options: {
-          banner: "(function(angular) {",
-          footer: "}(angular));"
-        }
+      options: {
+        banner: "(function(angular) {",
+        footer: "}(angular));"
       },
       dist: {
         src: ['src/main.js',


### PR DESCRIPTION
I just fixed the using of the banner/footer properties on grunt-concat task for wrapping up the distribution file inside a closure.

[Here is a reference of grunt-concat options implementation](https://github.com/gruntjs/grunt-contrib-concat#concatenating-with-a-custom-separator) from their docs, which I followed to fix this issue.

I'm just submitting the fix on the `gruntfile.js` to keep it an atomic PR, bear in mind a new release of the distribution files will be required to provide the fix for final users.

fixes #109
