### PR TITLE
fix datasource watch

### DIFF
--- a/angular-kendo.js
+++ b/angular-kendo.js
@@ -26,14 +26,36 @@
         // // directive and provide this data on the element.
         element.data('$kendoDataSource', ds);
 
-        // // Keep the element's data up-to-date with changes.
+        // Keep the element's data up-to-date with changes.
         scope.$watch(attrs.kDataSource, function(mew, old){
+          var role;
+          var widget;
+          var widgetType;
+
           if(mew !== old) {
             element.data('$kendoDataSource',
-              toDataSource(type, mew)
+              toDataSource(mew, type)
             );
+
+            // update the widget if any
+            // try getting widget from role attr
+            role = element.data("role");
+
+            if (role) {
+              widgetType = role.charAt(0).toUpperCase() + role.slice(1);
+              widget = element.data("kendo" + widgetType);
+            }
+
+            // if no role attr, try kendo.widgetInstance
+            if (!widget) {
+              widget = kendo.widgetInstance(element, kendo.ui);
+            }
+
+            if (widget && typeof widget.setDataSource === "function") {
+              widget.setDataSource(element.data('$kendoDataSource'));
+            }
           }
-        });
+        }, true);
 
         return ds;
 


### PR DESCRIPTION
this is addressing two issues:

1) fixed order of params when calling toDataSource in the $watch (see http://stackoverflow.com/questions/20982808/kendo-ui-chart-wont-update-using-angular); this would throw errors before

2) if there is a widget on the element which has a data source, update it with the
new data using a deep $watch; this addresses issues like https://github.com/kendo-labs/angular-kendo/issues/146 (for example, I believe there are others); using setDataSource since it seems to be relatively inexpensive and will refresh the widget (and the datasource was getting created anyway).

demo for chart + dropdown: http://jsbin.com/uqEgeCe/21/edit
