### PR TITLE
What is the use of cloning the element in the link()?

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,8 +95,8 @@
 
   <script src="app/components/google-code-prettify-lite/prettify.js"></script>
   <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular-route.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular-route.js"></script>
   <script src="http://cdn.kendostatic.com/2013.3.1119/js/kendo.all.min.js"></script>
   <script src="angular-kendo.js"></script>
   <script src="app/js/app.js"></script>


### PR DESCRIPTION
var originalElement = $(element)[0].cloneNode(true);

Why do we need this in link method? If we need then i see the 'originalElement' variable is only used when attrs.kRebind value is there? Could we move the statement under this condition? Since, we saw a memory leak issue that's why we moved the statement under the condition? If this change has any impact please let us know.
