### PR TITLE
Do not reset $viewValue back to the uninitialized widget value.

### DIFF
--- a/angular-kendo.js
+++ b/angular-kendo.js
@@ -255,8 +255,7 @@
                 if (currentVal != ngModel.$viewValue) {
                   if (!ngModel.$isEmpty(ngModel.$viewValue)) {
                     widget.value(ngModel.$viewValue);
-                  }
-                  if (currentVal != null && currentVal != "" && currentVal != ngModel.$viewValue) {
+                  } else if (currentVal != null && currentVal != "" && currentVal != ngModel.$viewValue) {
                     ngModel.$setViewValue(currentVal);
                   }
                 }


### PR DESCRIPTION
If currentVal != ngModel.$viewValue, and we reset widget.value() to be
the new ngModel.$viewValue, then it never makes sense to set
ngModel.$viewValue back to the old value.

Fixes issue #244.

Looks like this is a regression from a previous refactoring in commit 6e27524ce1712f5aaa04bb92d411bdae4c28395a, where var currentVal was extracted. Previously, the repeated calls to widget.value() would produce the updated value after widget.value() setter was called.
