### PR TITLE
Fix a bug when closing a grid edit modal box, avoid a blocking JS TypeError

### DIFF
--- a/angular-kendo.js
+++ b/angular-kendo.js
@@ -430,14 +430,17 @@
   }
 
   function destroyScope(scope, el) {
-    scope.$destroy();
-    if (el) {
-      // prevent leaks. https://github.com/kendo-labs/angular-kendo/issues/237
-      $(el)
-        .removeData("$scope")
-        .removeData("$isolateScope")
-        .removeData("$isolateScopeNoTemplate")
-        .removeClass("ng-scope");
+    // prevent TypeError: Cannot read property '$destroy' of undefined
+    if (typeof scope != 'undefined') {
+      scope.$destroy();
+      if (el) {
+        // prevent leaks. https://github.com/kendo-labs/angular-kendo/issues/237
+        $(el)
+          .removeData("$scope")
+          .removeData("$isolateScope")
+          .removeData("$isolateScopeNoTemplate")
+          .removeClass("ng-scope");
+      }
     }
   }
 


### PR DESCRIPTION
Proposed fix for https://github.com/kendo-labs/angular-kendo/issues/299
