### PR TITLE
Skip kendo-ui-core components that aren't available. #359

### DIFF
--- a/angular-kendo.js
+++ b/angular-kendo.js
@@ -516,6 +516,8 @@
       }
       klass = x;
     }
+    if (typeof klass === 'undefined')
+      return;
     var origMethod = klass.prototype[methodName];
     klass.prototype[methodName] = function() {
       var self = this, args = arguments;


### PR DESCRIPTION
Currently angular-kendo assumes that the entire kendo-ui-core library is being loaded. For those of of us using custom builds to select only the components we need, angular-kendo fails on line 519 because the class name passed into it doesn't exist.

This change short-circuits defadvice() so that it doesn't bother trying to hook up kendo-ui-core components that aren't available.
